### PR TITLE
fixed syntax in css grid slides

### DIFF
--- a/instructor_materials/IDM222-06-grid.md
+++ b/instructor_materials/IDM222-06-grid.md
@@ -795,7 +795,7 @@ theme: Plain Jane, 2
 .item-a {
   grid-column-start: 2;
   grid-column-end: five;
-  grid-row-start: row1-start
+  grid-row-start: row1-start;
   grid-row-end: 3
 }
 ```
@@ -812,7 +812,7 @@ theme: Plain Jane, 2
 .item-b {
   grid-column-start: 1;
   grid-column-end: span col4-start;
-  grid-row-start: 2
+  grid-row-start: 2;
   grid-row-end: span 2
 }
 ```


### PR DESCRIPTION
Slides 81 and 82 were missing semicolons at the end of the css. **NOTE** this only affects the markdown file in `instructor_materials`, not the custom .pdf presentation in the `resources` directory.